### PR TITLE
为邀请码增加可见范围控制

### DIFF
--- a/application/controllers/Admin.php
+++ b/application/controllers/Admin.php
@@ -316,11 +316,12 @@ class Admin extends CI_Controller
             $sub = $this->input->post('code_sub');
             $type = $this->input->post('code_type');
             $num = $this->input->post('code_num');
+            $owner = $this->input->post('code_owner');
             if ($type == "" || $num == "") {
                 echo '{"result" : "Not enougth args!" }';
                 return;
             }
-            if ($this->admin_model->add_code($sub, $type, $num))
+            if ($this->admin_model->add_code($sub, $type, $num, $owner))
             {
                 echo '{"result" : "success" }';
             }

--- a/application/models/Admin_model.php
+++ b/application/models/Admin_model.php
@@ -127,7 +127,7 @@ class Admin_model extends CI_Model
         return 0;
     }
 
-    function add_code($sub,$type,$num)
+    function add_code($sub,$type,$num, $owner)
     {
         $datas = array();
         for($a=0;$a<$num;$a++)
@@ -139,7 +139,8 @@ class Admin_model extends CI_Model
             $code = $sub.substr($x, rand(1, 13), 24);
             $data = array(
                 'code' => $code,
-                'user' => $type
+                'user' => $type,
+		'owner' => $owner,
             );
             array_push($datas, $data);
         }

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -237,8 +237,24 @@ class User_model extends CI_Model
 
     function get_invite_codes()
     {
+        $uid = $this->session->userdata('s_uid');
+	$this->db->where('uid', $uid);
+	$query = $this->db->get('ss_admin');
+	$only_mine = TRUE;
+        if ($query->num_rows() > 0)
+	{
+	    $only_mine = FALSE;
+	}
+
+	
         $this->db->where('user', '2');
         $this->db->where('used', '0');
+
+	if ($only_mine)
+	{
+	    $where = "( owner = 0 or owner = {$uid} or owner is NULL)";
+            $this->db->where($where);
+	}
         $query = $this->db->get('invite_code');
         if ($query->num_rows() > 0)
         {

--- a/application/views/admin/admin_codes.php
+++ b/application/views/admin/admin_codes.php
@@ -73,6 +73,10 @@ defined('BASEPATH') OR exit('No direct script access allowed');
                                 <label for="cate_title">邀请码数量</label>
                                 <input  class="form-control" id="code_num" name="code_num" placeholder="要生成的邀请码数量"  >
                             </div>
+                            <div class="form-group">
+                                <label for="cate_title">邀请码所有者</label>
+                                <input  class="form-control" id="code_owner" name="code_owner" placeholder="如果不填写或填写0，所有人可见；否则只有该ID用户才能看到这一邀请码"  >
+                            </div>
                         </div><!-- /.box-body -->
                         <div class="box-footer">
                             <button type="submit" name="action" value="add" class="btn btn-primary">添加</button>


### PR DESCRIPTION
新建类型2的邀请码时，可以输入Owner ID(uid)，只有指定用户才能看到这一邀请码。
如果不输入或者输入0，则所有用户都能看到。
