### PR TITLE
换用多说镜像，解决Gravatar被墙导致头像不显示的问题。

### DIFF
--- a/application/helpers/comm_helper.php
+++ b/application/helpers/comm_helper.php
@@ -15,7 +15,7 @@ if ( ! function_exists('get_gravatar'))
     //Gravatar
     function get_gravatar( $email, $s = 80, $d = 'mm', $r = 'g', $img = false, $atts = array() )
     {
-        $url = 'https://secure.gravatar.com/avatar/';
+        $url = 'http://gravatar.duoshuo.com/avatar/';
         $url .= md5( strtolower( trim( $email ) ) );
         $url .= "?s=$s&d=$d&r=$r";
         if ( $img )


### PR DESCRIPTION
换用多说镜像，解决Gravatar被墙导致头像不显示的问题。